### PR TITLE
feat(baseapp): readd query router for custom abci queries

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -192,7 +192,8 @@ func (app *BaseApp) Query(_ context.Context, req *abci.RequestQuery) (resp *abci
 
 	case QueryPathP2P:
 		resp = handleQueryP2P(app, path)
-
+	case QueryPathCustom:
+		resp = handleQueryCustom(app, path, req)
 	default:
 		resp = sdkerrors.QueryResult(errorsmod.Wrap(sdkerrors.ErrUnknownRequest, "unknown query path"), app.trace)
 	}
@@ -1084,6 +1085,43 @@ func handleQueryP2P(app *BaseApp, path []string) *abci.ResponseQuery {
 	}
 
 	return resp
+}
+
+func handleQueryCustom(app *BaseApp, path []string, req *abci.RequestQuery) *abci.ResponseQuery {
+	// path[0] should be "custom" because "/custom" prefix is required for keeper
+	// queries.
+	//
+	// The QueryRouter routes using path[1]. For example, in the path
+	// "custom/gov/proposal", QueryRouter routes using "gov".
+	if len(path) < 2 || path[1] == "" {
+		return sdkerrors.QueryResult(errorsmod.Wrap(sdkerrors.ErrUnknownRequest, "no route for custom query specified"), app.trace)
+	}
+
+	querier := app.customQueryRouter.Route(path[1])
+	if querier == nil {
+		return sdkerrors.QueryResult(errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "no custom querier found for route %s", path[1]), app.trace)
+	}
+
+	ctx, err := app.CreateQueryContext(req.Height, req.Prove)
+	if err != nil {
+		return sdkerrors.QueryResult(err, app.trace)
+	}
+
+	// Passes the rest of the path as an argument to the querier.
+	//
+	// For example, in the path "custom/gov/proposal/test", the gov querier gets
+	// []string{"proposal", "test"} as the path.
+	resBytes, err := querier(ctx, path[2:], req)
+	if err != nil {
+		res := sdkerrors.QueryResult(err, app.trace)
+		res.Height = req.Height
+		return res
+	}
+
+	return &abci.ResponseQuery{
+		Height: req.Height,
+		Value:  resBytes,
+	}
 }
 
 // SplitABCIQueryPath splits a string path using the delimiter '/'.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -67,6 +67,7 @@ type BaseApp struct {
 	cms               storetypes.CommitMultiStore // Main (uncached) state
 	qms               storetypes.MultiStore       // Optional alternative multistore for querying only.
 	storeLoader       StoreLoader                 // function to handle store loading, may be overridden with SetStoreLoader()
+	customQueryRouter sdk.QueryRouter             // router for redirecting custom abci query requests
 	grpcQueryRouter   *GRPCQueryRouter            // router for redirecting gRPC query calls
 	msgServiceRouter  *MsgServiceRouter           // router for redirecting Msg service messages
 	interfaceRegistry codectypes.InterfaceRegistry
@@ -203,17 +204,18 @@ func NewBaseApp(
 	name string, logger log.Logger, db dbm.DB, txDecoder sdk.TxDecoder, options ...func(*BaseApp),
 ) *BaseApp {
 	app := &BaseApp{
-		logger:           logger,
-		name:             name,
-		db:               db,
-		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default we use a no-op metric gather in store
-		storeLoader:      DefaultStoreLoader,
-		grpcQueryRouter:  NewGRPCQueryRouter(),
-		msgServiceRouter: NewMsgServiceRouter(),
-		txDecoder:        txDecoder,
-		fauxMerkleMode:   false,
-		sigverifyTx:      true,
-		queryGasLimit:    math.MaxUint64,
+		logger:            logger,
+		name:              name,
+		db:                db,
+		cms:               store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default we use a no-op metric gather in store
+		storeLoader:       DefaultStoreLoader,
+		customQueryRouter: NewQueryRouter(),
+		grpcQueryRouter:   NewGRPCQueryRouter(),
+		msgServiceRouter:  NewMsgServiceRouter(),
+		txDecoder:         txDecoder,
+		fauxMerkleMode:    false,
+		sigverifyTx:       true,
+		queryGasLimit:     math.MaxUint64,
 	}
 
 	for _, option := range options {
@@ -275,6 +277,9 @@ func (app *BaseApp) Logger() log.Logger {
 func (app *BaseApp) Trace() bool {
 	return app.trace
 }
+
+// CustomQueryRouter returns the custom QueryRouter of a BaseApp.
+func (app *BaseApp) CustomQueryRouter() sdk.QueryRouter { return app.customQueryRouter }
 
 // MsgServiceRouter returns the MsgServiceRouter of a BaseApp.
 func (app *BaseApp) MsgServiceRouter() *MsgServiceRouter { return app.msgServiceRouter }

--- a/baseapp/query_router.go
+++ b/baseapp/query_router.go
@@ -1,0 +1,50 @@
+package baseapp
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ sdk.QueryRouter = NewQueryRouter()
+
+// queryRouterCustom implements the QueryRouter interface.
+type queryRouterCustom struct {
+	routes map[string]sdk.Querier
+}
+
+// NewQueryRouter returns a reference to a new QueryRouter. This should be used for register custom abci
+// query handlers on the base application.
+func NewQueryRouter() sdk.QueryRouter {
+	return &queryRouterCustom{
+		routes: map[string]sdk.Querier{},
+	}
+}
+
+// AddRoute adds a query path to the router with a given Querier. It will panic
+// if a duplicate route is given. The route must be alphanumeric.
+func (qrt *queryRouterCustom) AddRoute(route string, q sdk.Querier) sdk.QueryRouter {
+	if !sdk.IsAlphaNumeric(route) {
+		panic("route expressions can only contain alphanumeric characters")
+	}
+
+	// paths are only the final extensions!
+	// Needed to ensure erroneous queries don't get into the state machine.
+	if strings.Contains(route, "/") {
+		panic("route's don't contain '/'")
+	}
+
+	if qrt.routes[route] != nil {
+		panic(fmt.Sprintf("route %s has already been initialized", route))
+	}
+
+	qrt.routes[route] = q
+
+	return qrt
+}
+
+// Route returns the Querier for a given query route path.
+func (qrt *queryRouterCustom) Route(path string) sdk.Querier {
+	return qrt.routes[path]
+}

--- a/baseapp/query_router_test.go
+++ b/baseapp/query_router_test.go
@@ -1,0 +1,33 @@
+package baseapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var testQuerier = func(_ sdk.Context, _ []string, _ *abci.RequestQuery) ([]byte, error) {
+	return nil, nil
+}
+
+func TestQueryRouter(t *testing.T) {
+	qr := NewQueryRouter()
+
+	// require panic on invalid route
+	require.Panics(t, func() {
+		qr.AddRoute("*", testQuerier)
+	})
+
+	qr.AddRoute("testRoute", testQuerier)
+	q := qr.Route("testRoute")
+	require.NotNil(t, q)
+
+	// require panic on duplicate route
+	require.Panics(t, func() {
+		qr.AddRoute("testRoute", testQuerier)
+	})
+}

--- a/types/router.go
+++ b/types/router.go
@@ -2,8 +2,20 @@ package types
 
 import (
 	"regexp"
+
+	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 // IsAlphaNumeric defines a regular expression for matching against alpha-numeric
 // values.
 var IsAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString
+
+// Querier defines a function type that a module querier must implement to handle
+// custom client queries.
+type Querier = func(ctx Context, path []string, req *abci.RequestQuery) ([]byte, error)
+
+// QueryRouter provides queryables for each query path.
+type QueryRouter interface {
+	AddRoute(r string, h Querier) QueryRouter
+	Route(path string) Querier
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Readds the `queryRouter` from 0.46 to baseapp. Labeled field as `customQueryRouter` on baesapp type.
Allows celestia-app to maintain functionality for both custom abci queries:
- TxInclusionQueryPath
- ShareInclusionQueryPath

Closes: [CEL-27](https://linear.app/binarybuilders/issue/CEL-27/handle-routing-of-custom-abci-queries)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
