### PR TITLE
chore: add secondary api to plumb codec opts in test encoding conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (baseapp) [#1](https://github.com/01builders/cosmos-sdk/pull/1) `SetProtocolVersion` has been renamed to `SetAppVersion`. It now updates the consensus params in baseapp's `ParamStore`.
 * (baseapp) [#2](https://github.com/01builders/cosmos-sdk/pull/2) Re-add query router for custom abci queries.
 * (x/auth/vesting) [#3](https://github.com/01builders/cosmos-sdk/pull/3) Add start time for continuous vesting accounts.
+* (testing) [#5](https://github.com/01builders/cosmos-sdk/pull/5) Add `MakeTestEncodingConfigWithOpts` to pass `testutil.CodecOptions` when creating `TestEncodingConfig`.
 
 ## [v0.50.11](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.11) - 2024-12-16
 

--- a/types/module/testutil/codec.go
+++ b/types/module/testutil/codec.go
@@ -43,8 +43,36 @@ func MakeTestEncodingConfig(modules ...module.AppModuleBasic) TestEncodingConfig
 	return encCfg
 }
 
+func MakeTestEncodingConfigWithOpts(codecOpts testutil.CodecOptions, modules ...module.AppModuleBasic) TestEncodingConfig {
+	aminoCodec := codec.NewLegacyAmino()
+	interfaceRegistry := codecOpts.NewInterfaceRegistry()
+	codec := codec.NewProtoCodec(interfaceRegistry)
+
+	encCfg := TestEncodingConfig{
+		InterfaceRegistry: interfaceRegistry,
+		Codec:             codec,
+		TxConfig:          tx.NewTxConfig(codec, tx.DefaultSignModes),
+		Amino:             aminoCodec,
+	}
+
+	mb := module.NewBasicManager(modules...)
+
+	std.RegisterLegacyAminoCodec(encCfg.Amino)
+	std.RegisterInterfaces(encCfg.InterfaceRegistry)
+	mb.RegisterLegacyAminoCodec(encCfg.Amino)
+	mb.RegisterInterfaces(encCfg.InterfaceRegistry)
+
+	return encCfg
+}
+
 func MakeTestTxConfig() client.TxConfig {
 	interfaceRegistry := testutil.CodecOptions{}.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+	return tx.NewTxConfig(cdc, tx.DefaultSignModes)
+}
+
+func MakeTestTxConfigWithOpts(codecOpts testutil.CodecOptions) client.TxConfig {
+	interfaceRegistry := codecOpts.NewInterfaceRegistry()
 	cdc := codec.NewProtoCodec(interfaceRegistry)
 	return tx.NewTxConfig(cdc, tx.DefaultSignModes)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Add a secondary api to plumb codec opts into test encoding config.
This allows us to leave the bulk of the existing sdk code alone, and not break test code requiring large changes.

Supersedes https://github.com/01builders/cosmos-sdk/pull/4

Adds the follow two funcs to ensure we're covered
- MakeTestEncodingConfigWithOpts
- MakeTestTxConfigWithOpts

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
